### PR TITLE
新增 播放出错自动重试

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -34,7 +34,8 @@ var jq = jQuery.noConflict();
 
     var playerSettings = {
         'showNameInDanmaku': false,
-        'preventLivePause': false
+        'preventLivePause': false,
+        'preventRetryError': false
     };
 
     function readPlayerSettings() {
@@ -92,6 +93,17 @@ var jq = jQuery.noConflict();
                     player.notice("阻止暂停功能已打开");
                 } else {
                     player.notice("阻止暂停功能已关闭");
+                }
+            },
+        },
+        {
+            text: '阻止失败刷新开关',
+            click: (player) => {
+                setPlayerSettings("preventRetryError", !playerSettings.preventRetryError);
+                if (playerSettings.preventRetryError) {
+                    player.notice("阻止失败刷新功能已打开");
+                } else {
+                    player.notice("阻止失败刷新功能已关闭");
                 }
             },
         },
@@ -169,6 +181,15 @@ var jq = jQuery.noConflict();
                 dp.notice("直播，请不要暂停", 1000);
             } else {
                 dp.notice("直播，建议不要暂停", 1000);
+            }
+        });
+
+        dp.plugins.flvjs.on(flvjs.Events.ERROR, (errType, errDetail) => {
+            if (playerSettings.preventRetryError) {
+                dp.notice("拉流出错，播放停止", 1000);
+            } else {
+                dp.notice("拉流出错，刷新页面中......", 1000);
+                location.reload();
             }
         });
 


### PR DESCRIPTION
近期发现 csscloud 平台偶发出现视频 CORS 校验失败的问题，从而导致视频播放卡住。另外教师端开始推流时，插件也无法自动开始拉流。

由于 CORS 校验失败、教师推流时间点并非我方可控情况，因此本 PR 新增了在播放出错时自动通过刷新页面的方式进行重试的功能。